### PR TITLE
fix: use resp.is_error instead of status_code != 200 for voice endpoints

### DIFF
--- a/src/amplifier_distro/server/apps/voice/__init__.py
+++ b/src/amplifier_distro/server/apps/voice/__init__.py
@@ -121,7 +121,7 @@ async def create_session() -> JSONResponse:
                 headers=headers,
             )
 
-        if resp.status_code != 200:
+        if resp.is_error:
             logger.error(
                 "OpenAI session creation failed: %d - %s",
                 resp.status_code,
@@ -200,7 +200,7 @@ async def exchange_sdp(request: Request) -> PlainTextResponse | JSONResponse:
                 headers=headers,
             )
 
-        if resp.status_code != 200:
+        if resp.is_error:
             logger.error(
                 "OpenAI SDP exchange failed: %d - %s",
                 resp.status_code,

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -168,6 +168,7 @@ class TestVoiceSessionEndpoint:
         """Session endpoint calls OpenAI and returns the response."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.is_error = False
         mock_response.json.return_value = {
             "client_secret": {"value": "ek_test_token", "expires_at": 9999999999},
             "model": "gpt-4o-realtime-preview",
@@ -197,6 +198,7 @@ class TestVoiceSessionEndpoint:
         """Session endpoint returns error when OpenAI rejects request."""
         mock_response = MagicMock()
         mock_response.status_code = 401
+        mock_response.is_error = True
         mock_response.text = "Invalid API key"
 
         mock_client = AsyncMock()
@@ -274,6 +276,7 @@ class TestVoiceSdpEndpoint:
         """SDP endpoint relays offer to OpenAI and returns answer."""
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.is_error = False
         mock_response.text = "v=0\r\no=- 12345 2 IN IP4 127.0.0.1\r\n"
 
         mock_client = AsyncMock()
@@ -305,6 +308,7 @@ class TestVoiceSdpEndpoint:
         """SDP endpoint returns error when OpenAI rejects SDP."""
         mock_response = MagicMock()
         mock_response.status_code = 400
+        mock_response.is_error = True
         mock_response.text = "Invalid SDP"
 
         mock_client = AsyncMock()


### PR DESCRIPTION
## Summary

- **Fix voice WebRTC connection failure** caused by OpenAI's Realtime API returning `201 Created` for the SDP exchange endpoint. The strict `resp.status_code != 200` check treated this as an error, wrapping the valid SDP answer in a JSON error response — which the browser's WebRTC stack could not parse.
- Replace `resp.status_code != 200` with httpx's `resp.is_error` property (True for 4xx/5xx only) in both the session creation and SDP exchange endpoints.
- Update test mocks to explicitly set `is_error` since `MagicMock` does not automatically simulate httpx response properties.

## Changes

- `src/amplifier_distro/server/apps/voice/__init__.py` — two status checks updated
- `tests/test_voice.py` — four test functions updated with `is_error` mock property

## Test plan

- [x] Existing voice unit tests updated and passing
- [ ] Manual test: verify voice WebRTC session connects successfully against OpenAI Realtime API

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)