### PR TITLE
fix: remove dead SessionHandle.run_streaming() method

### DIFF
--- a/src/amplifier_distro/bridge.py
+++ b/src/amplifier_distro/bridge.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -94,13 +93,6 @@ class SessionHandle:
             raise RuntimeError("Session not initialized")
         result: str = await self._session.execute(prompt)
         return result
-
-    async def run_streaming(self, prompt: str) -> AsyncIterator[str]:
-        """Send a prompt and stream the response."""
-        if self._session is None:
-            raise RuntimeError("Session not initialized")
-        async for chunk in self._session.run_streaming(prompt):
-            yield chunk
 
     async def cleanup(self) -> None:
         """Clean up session resources."""

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -99,22 +99,6 @@ class TestSessionHandle:
         with pytest.raises(RuntimeError, match="Session not initialized"):
             asyncio.run(handle.run("hello"))
 
-    def test_run_streaming_raises_when_session_is_none(self):
-        """run_streaming() must raise RuntimeError if _session is None."""
-        handle = SessionHandle(
-            session_id="test-123",
-            project_id="my-project",
-            working_dir=Path("/tmp"),
-            _session=None,
-        )
-
-        async def consume():
-            async for _chunk in handle.run_streaming("hello"):
-                pass
-
-        with pytest.raises(RuntimeError, match="Session not initialized"):
-            asyncio.run(consume())
-
     def test_session_excluded_from_repr(self):
         """_session should be excluded from repr (it's an internal handle)."""
         handle = SessionHandle(


### PR DESCRIPTION
## Summary

Removes `SessionHandle.run_streaming()` from the bridge API. This method was dead code that called `AmplifierSession.run_streaming()` -- a method that **does not exist** in amplifier-core and would raise `AttributeError` at runtime if ever invoked.

## What was removed

- `SessionHandle.run_streaming()` async generator method in `bridge.py`
- `from collections.abc import AsyncIterator` import (no longer needed)
- `test_run_streaming_raises_when_session_is_none` test in `test_bridge.py`

## Why

**`AmplifierSession` has no `run_streaming()` method.** Verified across the entire Amplifier ecosystem:

- amplifier-core: `AmplifierSession` exposes only `execute(prompt) -> str` for execution
- amplifier-foundation: No `run_streaming` on `Bundle`, `PreparedBundle`, or any API
- No deprecation or removal notices -- the method never existed in any version
- Zero callers in any Amplifier app, example, or module

**Streaming in Amplifier is event/hook-based, not iterator-based:**

```
session.execute(prompt) -> str
  -> loop-streaming orchestrator (internal async iterator)
    -> hooks.emit(CONTENT_BLOCK_*) -> real-time UI via hooks
  -> returns complete str
```

The bridge already implements this correctly via `BridgeStreamingHook`, which is registered on all core events in both `create_session()` and `resume_session()`.

## Validation

- Independently verified by 3 providers (Anthropic, OpenAI, Google) searching core source, foundation source, docs, examples, changelogs, and planning docs
- Zero references to `run_streaming` found outside `bridge.py` and its test
- 744 tests pass (1 pre-existing failure unrelated to this change -- missing `aiohttp` optional dep for Slack socket mode)

## Impact

None. The method had zero production callers. All server apps use `handle.run()` -> `session.execute()`. Streaming continues to work through `BridgeStreamingHook` + `on_stream` callback.