### PR TITLE
feat: add config validation and error handling

### DIFF
--- a/src/amplifier_distro/cli.py
+++ b/src/amplifier_distro/cli.py
@@ -18,7 +18,7 @@ from .config import (
 from .doctor import CheckStatus, DoctorReport, run_diagnostics, run_fixes
 from .migrate import migrate_memory
 from .preflight import PreflightReport, run_preflight
-from .schema import IdentityConfig
+from .schema import IdentityConfig, looks_like_path
 from .update_check import check_for_updates, get_version_info, run_self_update
 
 logger = logging.getLogger(__name__)
@@ -104,7 +104,12 @@ def init() -> None:
 
     # Workspace
     default_ws = detect_workspace_root()
-    ws = click.prompt("Workspace root", default=default_ws)
+    while True:
+        ws = click.prompt("Workspace root", default=default_ws)
+        if looks_like_path(ws):
+            break
+        click.echo(f"  '{ws}' doesn't look like a directory path.")
+        click.echo("  Enter a path like ~/dev or /home/user/projects.")
     config.workspace_root = ws
 
     # Save


### PR DESCRIPTION
## Summary

- Add path validation helpers (normalize_path, looks_like_path)
- Add workspace_root field validator to reject non-path values
- Enable validate_assignment for runtime validation
- Implement graceful config degradation (warn + defaults vs crash)
- Improve preflight diagnostics for invalid paths
- Add interactive validation loop in amp-distro init
- Add comprehensive test coverage for path validation

## Test plan

- [x] Path validation tests cover Unix, Windows, tilde, env vars, edge cases
- [x] Invalid workspace_root values rejected with clear error messages
- [x] Server starts with defaults when config is corrupted
- [x] Interactive init loop guides users to valid input

## Changes

**Group 1: Config Validation & Error Handling**
- schema.py: Path validation infrastructure
- config.py: Graceful degradation on ValidationError
- preflight.py: Better path validation diagnostics
- cli.py: Interactive validation in init command
- tests/test_phase0.py: Comprehensive test coverage

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)