### PR TITLE
fix: add factory pattern for uvicorn --reload and dev mode warning

### DIFF
--- a/src/amplifier_distro/server/cli.py
+++ b/src/amplifier_distro/server/cli.py
@@ -44,7 +44,7 @@ from amplifier_distro import conventions
 @click.option(
     "--dev",
     is_flag=True,
-    help="Dev mode: skip wizard, use existing environment",
+    help="Dev mode: skip wizard, use existing environment, mock session backend (no LLM)",
 )
 @click.option(
     "--stub",
@@ -89,7 +89,7 @@ def serve(
 @click.option(
     "--dev",
     is_flag=True,
-    help="Dev mode: skip wizard, use existing environment",
+    help="Dev mode: skip wizard, use existing environment, mock session backend (no LLM)",
 )
 def start(host: str, port: int, apps_dir: str | None, dev: bool) -> None:
     """Start the server as a background daemon."""
@@ -166,7 +166,7 @@ def stop() -> None:
 @click.option(
     "--dev",
     is_flag=True,
-    help="Dev mode: skip wizard, use existing environment",
+    help="Dev mode: skip wizard, use existing environment, mock session backend (no LLM)",
 )
 @click.pass_context
 def restart(
@@ -459,13 +459,35 @@ def _run_foreground(
         click.echo(f"  URL: http://{host}:{port}")
     click.echo(f"  API docs:  http://{host}:{port}/api/docs")
 
-    uvicorn.run(
-        server.app,
-        host=host,
-        port=port,
-        reload=reload,
-        log_level="info",
-    )
+    if dev:
+        click.echo(
+            click.style(
+                "  NOTE: --dev uses mock session backend (no LLM). "
+                "Remove --dev for real Amplifier sessions.",
+                fg="yellow",
+            )
+        )
+
+    if reload:
+        import os as _os
+        _os.environ["_AMPLIFIER_DEV_MODE"] = "1" if dev else ""
+        if apps_dir:
+            _os.environ["_AMPLIFIER_APPS_DIR"] = apps_dir
+        uvicorn.run(
+            "amplifier_distro.server.cli:_create_app",
+            host=host,
+            port=port,
+            reload=True,
+            factory=True,
+            log_level="info",
+        )
+    else:
+        uvicorn.run(
+            server.app,
+            host=host,
+            port=port,
+            log_level="info",
+        )
 
     # Auto-backup on shutdown (if enabled in distro.yaml)
     try:
@@ -547,3 +569,38 @@ def _create_default_config() -> None:
     )
     save_config(cfg)
     click.echo(f"  Created: {cfg.workspace_root} ({gh_handle or 'no gh handle'})")
+
+
+def _create_app():
+    """Factory for uvicorn --reload mode.
+
+    Returns a FastAPI/ASGI app instance. Called by uvicorn when using
+    import-string mode (required for --reload to work).
+
+    Configuration is passed from the supervisor process via environment
+    variables (_AMPLIFIER_DEV_MODE, _AMPLIFIER_APPS_DIR) because the
+    worker is a fresh Python process with no access to CLI args.
+    """
+    import os
+
+    from amplifier_distro.server.app import create_server
+    from amplifier_distro.server.services import init_services
+    from amplifier_distro.server.startup import export_keys, setup_logging
+
+    dev_mode = os.environ.get("_AMPLIFIER_DEV_MODE") == "1"
+
+    setup_logging()
+    export_keys()
+    init_services(dev_mode=dev_mode)
+
+    server = create_server(dev_mode=dev_mode)
+
+    apps_dir = os.environ.get("_AMPLIFIER_APPS_DIR")
+    if apps_dir:
+        server.discover_apps(Path(apps_dir))
+    else:
+        builtin_apps = Path(__file__).parent / "apps"
+        if builtin_apps.exists():
+            server.discover_apps(builtin_apps)
+
+    return server.app

--- a/src/amplifier_distro/server/startup.py
+++ b/src/amplifier_distro/server/startup.py
@@ -61,12 +61,16 @@ def setup_logging(log_file: Path | None = None, level: int = logging.INFO) -> No
         log_file: Path for the JSON log file. Uses convention default if None.
         level: Logging level for both handlers.
     """
+    root = logging.getLogger()
+    # Prevent duplicate handlers on uvicorn reload
+    if root.handlers:
+        return
+
     if log_file is None:
         log_file = log_file_path()
 
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
-    root = logging.getLogger()
     root.setLevel(level)
 
     # Console handler: human-readable

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -360,7 +360,9 @@ class TestStructuredLogging:
 
     def test_setup_creates_log_file(self, tmp_path: Path) -> None:
         log_file = tmp_path / "test.log"
-        # Use a unique logger to avoid polluting the root
+        # Clear existing handlers so the idempotency guard doesn't skip
+        root = logging.getLogger()
+        root.handlers.clear()
         setup_logging(log_file=log_file)
         root = logging.getLogger()
         try:


### PR DESCRIPTION
## Summary

Fixes `--reload` mode (was broken) and adds a clear dev mode warning.

### What was broken
`uvicorn.run(server.app, reload=True)` doesn't work -- uvicorn's reload spawns a fresh Python process and needs an import string to reconstruct the app. Passing a live object means the new process can't find it.

### Changes

**server/cli.py:**
- Split uvicorn.run into reload vs non-reload paths
- Reload mode uses `"amplifier_distro.server.cli:_create_app"` with `factory=True`
- Env-var IPC (`_AMPLIFIER_DEV_MODE`, `_AMPLIFIER_APPS_DIR`) bridges supervisor -> worker
- Added yellow warning when `--dev` is active explaining mock backend behavior
- Updated `--dev` help text to clarify it uses mock session backend

**server/startup.py:**
- `setup_logging()` is now idempotent -- guards against duplicate handlers on reload

### Swarm feedback incorporated
- **`setup_logging()` idempotency** (Google: duplicate handlers on reload = every log prints N times)
- **`== "1"` not `bool()`** for dev mode parsing (OpenAI: `bool("0")` is `True` in Python)
- **Underscore-prefixed env vars** confirmed as standard uvicorn pattern (all 3 providers agreed)

## Tests

729/729 pass (updated test_daemon.py to clear handlers before setup_logging call).

Split from #6 (now closed). Part 2 of 2.