### PR TITLE
feat: replace name-based bundle resolution with convention-path loading

### DIFF
--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -294,6 +294,7 @@ class TestLocalBridgeCreateSession:
         }
         config = BridgeConfig(
             working_dir=Path("~/dev/test-project").expanduser(),
+            bundle_name="test-bundle",
             run_preflight=False,
         )
         return bridge, config


### PR DESCRIPTION
## Summary

- **Problem:** Bridge resolves bundles by name through the CLI registry, but that name doesn't exist in the registry. `_inject_providers()` silently compensates, masking the failure.
- **Fix:** Load from the convention path `~/.amplifier/bundles/distro.yaml` directly instead of looking up a bundle name.
- **What changed:**
  - Added `_resolve_distro_bundle()` helper to eliminate code duplication
  - Wrapped `load_bundle()` in try/except for actionable error messages on malformed YAML
  - Fixed a would-be `NameError` in logging (variable renamed from `bundle_name` to `bundle_ref` but logging lines weren't updated)
  - Tests updated to pass `bundle_name` explicitly since the bridge no longer reads `bundle.active` from config

See `specs/distro-004-bundle-structure.md` for the full spec and swarm evaluation findings.

## Test plan

- [x] 34/34 bridge tests pass
- [x] Only pre-existing `test_install_wizard` failure remains (unrelated)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)