### PR TITLE
fix: atomic file writes for crash-safe session persistence

### DIFF
--- a/src/amplifier_distro/config.py
+++ b/src/amplifier_distro/config.py
@@ -48,9 +48,11 @@ def save_config(config: DistroConfig) -> None:
     path = config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    from amplifier_distro.fileutil import atomic_write
+
     data = config.model_dump()
     text = yaml.dump(data, default_flow_style=False, sort_keys=False)
-    path.write_text(text)
+    atomic_write(path, text)
 
 
 def detect_github_identity() -> tuple[str, str]:

--- a/src/amplifier_distro/fileutil.py
+++ b/src/amplifier_distro/fileutil.py
@@ -1,0 +1,42 @@
+"""File utilities for amplifier-distro.
+
+Provides atomic_write() for crash-safe file persistence.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Write content to *path* atomically via temp-file + rename.
+
+    Guarantees that *path* is never left in a truncated or partially-written
+    state.  On success the file contains exactly *content*; on any failure
+    the previous file (if any) is untouched.
+
+    Uses ``os.fdopen`` to handle short writes internally, and ``os.fsync``
+    to ensure data is durable before renaming.
+
+    Works on all platforms (``os.replace`` is atomic on POSIX; on Windows it
+    is atomic when source and destination are on the same volume).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = -1  # os.fdopen owns the fd now
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        # Clean up temp file on failure (best-effort)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise

--- a/src/amplifier_distro/server/apps/slack/sessions.py
+++ b/src/amplifier_distro/server/apps/slack/sessions.py
@@ -119,7 +119,9 @@ class SlackSessionManager:
                 }
                 for m in self._mappings.values()
             ]
-            self._persistence_path.write_text(json.dumps(data, indent=2))
+            from amplifier_distro.fileutil import atomic_write
+
+            atomic_write(self._persistence_path, json.dumps(data, indent=2))
         except OSError:
             logger.warning("Failed to save session mappings", exc_info=True)
 

--- a/src/amplifier_distro/server/memory.py
+++ b/src/amplifier_distro/server/memory.py
@@ -233,7 +233,9 @@ class MemoryService:
         """Save the memory store to disk."""
         self._ensure_dir()
         data = {"memories": [m.model_dump() for m in store.memories]}
-        self._store_path.write_text(yaml.dump(data, default_flow_style=False))
+        from amplifier_distro.fileutil import atomic_write
+
+        atomic_write(self._store_path, yaml.dump(data, default_flow_style=False))
 
     def _load_work_log(self) -> WorkLog:
         """Load the work log from disk."""
@@ -250,7 +252,9 @@ class MemoryService:
         """Save the work log to disk."""
         self._ensure_dir()
         data = {"items": [item.model_dump() for item in log.items]}
-        self._work_log_path.write_text(yaml.dump(data, default_flow_style=False))
+        from amplifier_distro.fileutil import atomic_write
+
+        atomic_write(self._work_log_path, yaml.dump(data, default_flow_style=False))
 
     def _next_id(self, store: MemoryStore) -> str:
         """Generate the next memory ID (mem-001, mem-002, etc.)."""

--- a/tests/test_fileutil.py
+++ b/tests/test_fileutil.py
@@ -1,0 +1,97 @@
+"""Tests for atomic_write utility.
+
+Verifies that file writes are crash-safe: the target file is never
+left in a truncated or partially-written state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from amplifier_distro.fileutil import atomic_write
+
+
+class TestAtomicWrite:
+    """Verify atomic_write() crash-safety and correctness."""
+
+    def test_writes_content_to_new_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "test.json"
+        atomic_write(target, '{"key": "value"}')
+        assert target.read_text() == '{"key": "value"}'
+
+    def test_overwrites_existing_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "test.json"
+        target.write_text("old content")
+        atomic_write(target, "new content")
+        assert target.read_text() == "new content"
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        target = tmp_path / "sub" / "dir" / "test.json"
+        atomic_write(target, "nested")
+        assert target.read_text() == "nested"
+
+    def test_preserves_original_on_write_failure(self, tmp_path: Path) -> None:
+        """If os.replace fails, the original file is untouched."""
+        target = tmp_path / "test.json"
+        target.write_text("original")
+
+        with (
+            patch(
+                "amplifier_distro.fileutil.os.replace", side_effect=OSError("disk full")
+            ),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            atomic_write(target, "should not appear")
+
+        assert target.read_text() == "original"
+
+    def test_cleans_up_temp_file_on_failure(self, tmp_path: Path) -> None:
+        """Temp file is removed if os.replace fails."""
+        target = tmp_path / "test.json"
+
+        with (
+            patch(
+                "amplifier_distro.fileutil.os.replace", side_effect=OSError("disk full")
+            ),
+            pytest.raises(OSError),
+        ):
+            atomic_write(target, "content")
+
+        # No .tmp files should remain
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert tmp_files == [], f"Temp files not cleaned up: {tmp_files}"
+
+    def test_handles_unicode_content(self, tmp_path: Path) -> None:
+        target = tmp_path / "unicode.txt"
+        content = "Hello \u2014 \u4e16\u754c"
+        atomic_write(target, content)
+        assert target.read_text(encoding="utf-8") == content
+
+    def test_empty_content(self, tmp_path: Path) -> None:
+        target = tmp_path / "empty.txt"
+        atomic_write(target, "")
+        assert target.read_text() == ""
+
+    def test_preserves_original_on_write_phase_failure(self, tmp_path: Path) -> None:
+        """If the write itself fails (not replace), original is untouched."""
+        target = tmp_path / "test.json"
+        target.write_text("original")
+
+        with patch(
+            "amplifier_distro.fileutil.os.fdopen",
+            side_effect=OSError("EIO"),
+        ), pytest.raises(OSError, match="EIO"):
+            atomic_write(target, "should not appear")
+
+        assert target.read_text() == "original"
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_no_temp_files_left_on_success(self, tmp_path: Path) -> None:
+        """After successful write, no .tmp files remain."""
+        target = tmp_path / "test.json"
+        atomic_write(target, "content")
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert tmp_files == []


### PR DESCRIPTION
## Summary

Adds `atomic_write()` utility that writes via temp-file + `os.replace()`, guaranteeing the target file is never left truncated or partially written on crash.

Applied to the three highest-risk persistence paths:
- **Slack session mappings** (`slack-sessions.json`) — high frequency, runtime
- **Distro config** (`distro.yaml`) — user settings
- **Memory store + work log** — runtime persistence

## Changes

- New: `fileutil.py` with `atomic_write()` (temp + `os.replace`)
- `slack/sessions.py`: `_save_sessions` uses `atomic_write`
- `config.py`: `save_config` uses `atomic_write`
- `server/memory.py`: `_save_store` and `_save_work_log` use `atomic_write`
- New: `tests/test_fileutil.py` — 8 tests

## Test Results

956 tests pass. Zero regressions.

Closes #19