### PR TITLE
feat: session lifecycle governance — eviction, cap, metadata tracking

### DIFF
--- a/src/amplifier_distro/server/app.py
+++ b/src/amplifier_distro/server/app.py
@@ -499,6 +499,7 @@ class DistroServer:
                     working_dir=body.get("working_dir", "."),
                     bundle_name=body.get("bundle_name"),
                     description=body.get("description", ""),
+                    surface="api",
                 )
                 return JSONResponse(
                     content={
@@ -648,6 +649,7 @@ class DistroServer:
             if phase == "unconfigured":
                 return RedirectResponse(url="/apps/install-wizard/")
             return HTMLResponse(content=_landing_page.read_text())
+
 
 def create_server(dev_mode: bool = False, **kwargs: Any) -> DistroServer:
     """Factory function to create and configure the server.

--- a/src/amplifier_distro/server/apps/routines/__init__.py
+++ b/src/amplifier_distro/server/apps/routines/__init__.py
@@ -228,6 +228,7 @@ class SchedulerService:
             working_dir=str(Path.home()),
             bundle_name="routines",
             description=f"Routine execution: {name}",
+            surface="routines",
         )
 
         prompt = (

--- a/src/amplifier_distro/server/apps/slack/sessions.py
+++ b/src/amplifier_distro/server/apps/slack/sessions.py
@@ -188,6 +188,7 @@ class SlackSessionManager:
             working_dir=self._config.default_working_dir,
             bundle_name=self._config.default_bundle,
             description=description,
+            surface="slack",
         )
 
         # Determine the conversation key
@@ -240,6 +241,7 @@ class SlackSessionManager:
             working_dir=working_dir,
             bundle_name=self._config.default_bundle,
             description=description,
+            surface="slack",
         )
 
         key = f"{channel_id}:{thread_ts}" if thread_ts else channel_id

--- a/src/amplifier_distro/server/apps/web_chat/__init__.py
+++ b/src/amplifier_distro/server/apps/web_chat/__init__.py
@@ -211,6 +211,7 @@ async def create_session(request: Request) -> JSONResponse:
             info = await backend.create_session(
                 working_dir=body.get("working_dir", "~"),
                 description=body.get("description", "Web chat session"),
+                surface="web-chat",
             )
             _active_session_id = info.session_id
 


### PR DESCRIPTION
## Summary

Adds session lifecycle management to BridgeBackend: idle eviction, global session cap, and per-session metadata tracking.

## Changes

- **SessionMeta dataclass**: tracks `created_by_surface`, `created_at`, `last_active`
- **Global session cap** (default 50): `create_session()` rejects when full
- **Lazy idle eviction**: cap hit triggers eviction of idle sessions first (default 1hr timeout)
- **Activity tracking**: `send_message()` touches `last_active` on every call
- **Metadata cleanup**: `end_session()` removes metadata entry
- **Rich session info**: `list_active_sessions()` and `get_session_info()` include metadata

## Tests

10 new tests across 3 test classes:
- `TestSessionMeta`: creation time, touch, idle tracking
- `TestBridgeBackendSessionCap`: reject when full, evict idle before reject
- `TestBridgeBackendMetadata`: surface tracking, last_active update, cleanup, list metadata

957 tests pass. Zero regressions.

Closes #21
Closes #24