### PR TITLE
fix: create workspace directory during init if it doesn't exist

### DIFF
--- a/src/amplifier_distro/cli.py
+++ b/src/amplifier_distro/cli.py
@@ -19,7 +19,7 @@ from .config import (
 from .doctor import CheckStatus, DoctorReport, run_diagnostics, run_fixes
 from .migrate import migrate_memory
 from .preflight import PreflightReport, run_preflight
-from .schema import DistroConfig, IdentityConfig, looks_like_path
+from .schema import DistroConfig, IdentityConfig, looks_like_path, normalize_path
 from .update_check import check_for_updates, get_version_info, run_self_update
 
 logger = logging.getLogger(__name__)
@@ -138,6 +138,12 @@ def init() -> None:
             break
         click.echo(f"  '{ws}' doesn't look like a path (should start with /, ~, or .)")
     config.workspace_root = ws
+
+    # Ensure workspace directory exists
+    ws_path = Path(normalize_path(ws)).resolve()
+    if not ws_path.exists():
+        click.echo(f"  Creating {ws_path}")
+    ws_path.mkdir(parents=True, exist_ok=True)
 
     # Save
     save_config(config)


### PR DESCRIPTION
## Summary

- The `amp-distro init` command prompts the user for a workspace root directory, but if that directory doesn't exist, subsequent steps (config save, memory migration) fail.
- This fix resolves and creates the directory (with parents) immediately after the path is validated, before saving the config.
- Minimal change: 6 lines added to `src/amplifier_distro/cli.py`.

## Test plan

- [x] All 840 existing tests pass
- [x] Manual: run `amp-distro init` with a non-existent workspace path — directory is created and init completes successfully
- [x] Manual: run `amp-distro init` with an existing workspace path — no change in behavior

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)