### PR TITLE
feat: add NON_ONBOARDING_PROVIDERS constant

### DIFF
--- a/src/amplifier_distro/features.py
+++ b/src/amplifier_distro/features.py
@@ -124,6 +124,9 @@ PROVIDERS: dict[str, Provider] = {
     ),
 }
 
+# Providers excluded from onboarding wizard and model picker fallback
+NON_ONBOARDING_PROVIDERS: frozenset[str] = frozenset({"ollama", "azure", "vllm"})
+
 
 FEATURES: dict[str, Feature] = {
     "dev-memory": Feature(


### PR DESCRIPTION
Kepler Desktop filters out infrastructure providers (ollama, azure, vllm) from the onboarding wizard and model picker — users shouldn't see providers that require special environment setup. The filtering logic imports `NON_ONBOARDING_PROVIDERS` from the distro's `features.py`, but the constant doesn't exist there yet.

This adds it — a simple `frozenset` of provider IDs that aren't user-facing. Additive only, nothing changes for existing code.

```python
NON_ONBOARDING_PROVIDERS: frozenset[str] = frozenset({"ollama", "azure", "vllm"})
```