### PR TITLE
feat: add self_service field to Provider dataclass

### DIFF
--- a/src/amplifier_distro/features.py
+++ b/src/amplifier_distro/features.py
@@ -36,6 +36,7 @@ class Provider:
     fallback_models: tuple[str, ...] = ()
     base_url: str | None = None
     api_key_config: str | None = None
+    self_service: bool = True  # False = requires infrastructure (Ollama server, Azure endpoint, etc.)
 
 
 PROVIDERS: dict[str, Provider] = {
@@ -108,6 +109,7 @@ PROVIDERS: dict[str, Provider] = {
         source_url="git+https://github.com/microsoft/amplifier-module-provider-ollama@main",
         console_url="https://ollama.com/",
         fallback_models=("llama3.1", "mistral", "codellama"),
+        self_service=False,
     ),
     "azure": Provider(
         id="azure",
@@ -121,6 +123,7 @@ PROVIDERS: dict[str, Provider] = {
         source_url="git+https://github.com/microsoft/amplifier-module-provider-azure-openai@main",
         console_url="https://portal.azure.com/",
         fallback_models=("gpt-4o", "gpt-4o-mini"),
+        self_service=False,
     ),
 }
 


### PR DESCRIPTION
Some providers (Ollama, Azure) require infrastructure — a running local server or an enterprise endpoint. Regular users signing up for an API key can't use them.

Today, interfaces that want to filter these from onboarding or model pickers have to hardcode a list of provider IDs. That's fragile and duplicated across CLI, TUI, Desktop.

This adds `self_service: bool = True` to the `Provider` dataclass. Providers that need infrastructure get `self_service=False`. Any interface can now filter with `if p.self_service` instead of maintaining its own exclusion list.

Additive only — defaults to `True`, so all existing providers behave identically. Only `ollama` and `azure` are flagged `False`.