### PR TITLE
feat: improve amp-distro update and version commands

### DIFF
--- a/src/amplifier_distro/cli.py
+++ b/src/amplifier_distro/cli.py
@@ -572,12 +572,29 @@ def version() -> None:
     info = get_version_info()
 
     click.echo("Amplifier Distro - Version\n")
-    click.echo(f"  amplifier-distro:  {info.distro_version}")
-    if info.amplifier_version:
-        click.echo(f"  amplifier:         {info.amplifier_version}")
-    else:
-        click.echo("  amplifier:         not installed")
-    click.echo(f"  Python:            {info.python_version}")
+
+    for label, pkg in [
+        ("amplifier-distro", info.distro),
+        ("amplifier", info.amplifier),
+        ("amplifier-tui", info.tui),
+    ]:
+        if pkg is None:
+            click.echo(f"  {label + ':':<19} not installed")
+            continue
+        if not pkg.installed:
+            click.echo(f"  {label + ':':<19} not installed")
+            continue
+        parts = [pkg.version]
+        if pkg.local_sha:
+            parts.append(pkg.local_sha)
+        line = f"  {label + ':':<19} {' '.join(parts)}"
+        if pkg.update_available is True:
+            line += f"  (latest: {pkg.remote_sha})"
+        elif pkg.update_available is False:
+            line += "  (up to date)"
+        click.echo(line)
+
+    click.echo(f"\n  Python:            {info.python_version}")
     click.echo(f"  Platform:          {info.platform}")
     click.echo(f"  Install method:    {info.install_method}")
 

--- a/src/amplifier_distro/conventions.py
+++ b/src/amplifier_distro/conventions.py
@@ -112,6 +112,13 @@ PYPI_PACKAGE_NAME = "amplifier-distro"
 GITHUB_REPO = "ramparte/amplifier-distro"
 GITHUB_REPO_URL = "https://github.com/ramparte/amplifier-distro"
 
+# Package-to-repo mapping for version/update checks
+PACKAGE_REPOS: dict[str, str] = {
+    "amplifier-distro": GITHUB_REPO,
+    "amplifier-app-cli": "microsoft/amplifier",
+    "amplifier-tui": "ramparte/amplifier-tui",
+}
+
 # --- Project-Level Conventions ---
 # These files may appear in a project's working directory
 PROJECT_AGENTS_FILENAME = "AGENTS.md"


### PR DESCRIPTION
## Summary
- **Self-update**: `amp-distro update` detects editable vs uv tool installs and acts accordingly — editable gets a message to use git, tool installs get `uv tool install --force` from git HEAD
- **SHA-based version tracking**: `amp-distro version` now shows local and remote git SHAs for all three packages (distro, amplifier, tui), with "(up to date)" or "(latest: ...)" indicators
- **Conventions cleanup**: moved `PACKAGE_REPOS` mapping to `conventions.py`, removed redundant `distro_version`/`amplifier_version` fields from `VersionInfo`
- **Test updates**: updated all CLI enhancement tests to match new behavior (check_for_updates disabled, editable-aware self-update, SHA-based comparison)

## Test plan
- [x] `pytest tests/test_cli_enhancements.py` — 32/32 pass
- [x] Full suite — 966 passed, 2 pre-existing failures unrelated to this PR
- [ ] Manual: `amp-distro version` shows SHAs and update status
- [ ] Manual: `amp-distro update` on editable install shows git message
- [ ] Manual: `amp-distro update` on tool install runs uv reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)