### PR TITLE
fix: remove max_sessions_per_user cap from Slack bridge

### DIFF
--- a/src/amplifier_distro/server/apps/slack/config.py
+++ b/src/amplifier_distro/server/apps/slack/config.py
@@ -116,7 +116,6 @@ class SlackConfig:
 
     # --- Limits ---
     max_message_length: int = 3900
-    max_sessions_per_user: int = 10
     response_timeout: int = 300
 
     # --- Mode ---


### PR DESCRIPTION
## Summary
- Removes the `max_sessions_per_user` field from `SlackConfig` (was defaulting to 10)
- Removes the per-user session limit guard from `create_session()` and `connect_session()` in `SlackSessionManager`
- Cleans up a stale comment in `route_message()` that referenced the now-gone cap
- Drops `test_session_limit` and `test_zombie_session_freed_from_limit` tests; updates `TestZombieSessionFix` docstring

## Context

The `max_sessions_per_user` limit was introduced alongside the zombie-session fix (#31) as an extra guard against zombie sessions eating up slots. On reflection the cap is unnecessary — the correct fix (deactivating a `SlackSessionMapping` when the backend raises `ValueError`) is already in place and is sufficient on its own. A hard cap adds complexity and could frustrate legitimate users with many concurrent sessions, so it's removed entirely.

## Test plan
- [ ] Existing zombie-session tests still pass (`TestZombieSessionFix`)
- [ ] No references to `max_sessions_per_user` remain in source or tests
- [ ] `create_session()` / `connect_session()` work without hitting an artificial limit

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)