### PR TITLE
fix: parse --dir flag in @amp new command

### DIFF
--- a/src/amplifier_distro/server/apps/slack/commands.py
+++ b/src/amplifier_distro/server/apps/slack/commands.py
@@ -193,6 +193,18 @@ class CommandHandler:
 
     async def cmd_new(self, args: list[str], ctx: CommandContext) -> CommandResult:
         """Start a new Amplifier session."""
+        working_dir: str | None = None
+
+        # Parse optional --dir <path> flag
+        if "--dir" in args:
+            idx = args.index("--dir")
+            if idx + 1 >= len(args):
+                return CommandResult(
+                    text="Missing value for `--dir`. Usage: `new [--dir <path>] [description]`"
+                )
+            working_dir = args[idx + 1]
+            args = args[:idx] + args[idx + 2 :]
+
         description = " ".join(args) if args else ""
 
         try:
@@ -201,6 +213,7 @@ class CommandHandler:
                 thread_ts=ctx.thread_ts,
                 user_id=ctx.user_id,
                 description=description,
+                working_dir=working_dir,
             )
         except ValueError as e:
             return CommandResult(text=str(e))

--- a/tests/test_slack_bridge.py
+++ b/tests/test_slack_bridge.py
@@ -838,6 +838,46 @@ class TestCommandHandler:
         result = asyncio.run(command_handler.handle("new", ["test"], ctx))
         assert "default_working_dir" not in result.text
 
+
+    def test_cmd_new_dir_flag_sets_working_directory(self, command_handler, slack_config):
+        """--dir flag overrides the config default_working_dir."""
+        from amplifier_distro.server.apps.slack.commands import CommandContext
+
+        slack_config.default_working_dir = "~"
+        ctx = CommandContext(channel_id="C_HUB", user_id="U1", thread_ts=None)
+        result = asyncio.run(
+            command_handler.handle("new", ["--dir", "/Users/samule/repo/myproject"], ctx)
+        )
+        assert "/Users/samule/repo/myproject" in result.text
+        # Explicit --dir should not trigger the "set default_working_dir" tip
+        assert "default_working_dir" not in result.text
+
+    def test_cmd_new_dir_flag_with_description(self, command_handler, slack_config):
+        """--dir extracts the path; remaining args become the session description."""
+        from amplifier_distro.server.apps.slack.commands import CommandContext
+
+        ctx = CommandContext(channel_id="C_HUB", user_id="U1", thread_ts=None)
+        result = asyncio.run(
+            command_handler.handle(
+                "new", ["--dir", "/some/path", "fix", "the", "auth", "bug"], ctx
+            )
+        )
+        # Path must appear as the working dir ("in `/some/path`"), not as part of description
+        assert "in `/some/path`" in result.text
+        # Description must be the remaining args only — --dir should not bleed into it
+        assert "--dir" not in result.text
+        assert "fix the auth bug" in result.text
+
+    def test_cmd_new_dir_flag_missing_value_returns_error(self, command_handler):
+        """--dir without a path argument returns a usage error, no session created."""
+        from amplifier_distro.server.apps.slack.commands import CommandContext
+
+        ctx = CommandContext(channel_id="C_HUB", user_id="U1", thread_ts=None)
+        result = asyncio.run(command_handler.handle("new", ["--dir"], ctx))
+        # Should NOT start a session — must return an error
+        assert "Started new session" not in result.text
+        assert "--dir" in result.text
+
     def test_cmd_status_no_session(self, command_handler):
         from amplifier_distro.server.apps.slack.commands import CommandContext
 


### PR DESCRIPTION
## Summary

- **Bug:** `@amp new --dir /path` was treating `--dir /path` as description text instead of a directory argument, causing new sessions to land in `~` (home directory) instead of the specified path
- **Root cause:** `cmd_new` had no flag parsing logic — all args after the command were joined as the session description. Issue #34 was closed prematurely without this being caught.
- **Fix:** `--dir <path>` is now extracted from args before building the description and is passed directly to `create_session`. An error is returned if `--dir` is provided with no value.

## What changed

- Added `--dir` flag parsing in `cmd_new` — extracted from args before description assembly
- Parsed dir path forwarded to `create_session` so the session is created in the correct directory
- Returns a clear error if `--dir` is specified without a following path value
- 3 new tests added covering: correct dir passed through, `--dir` stripped from description, and error on missing `--dir` value

## Test plan

- [x] `@amp new --dir /some/path My session` creates session in `/some/path`
- [x] `--dir /path` does not appear in the session description
- [x] `@amp new --dir` (no value) returns an error
- [x] Existing `@amp new` behaviour without `--dir` unchanged

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)