### PR TITLE
fix: register module in sys.modules before executing in discover_apps

### DIFF
--- a/src/amplifier_distro/server/app.py
+++ b/src/amplifier_distro/server/app.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -206,6 +207,7 @@ class DistroServer:
                     continue
 
                 module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = module
                 spec.loader.exec_module(module)
 
                 if hasattr(module, "manifest"):


### PR DESCRIPTION
## Summary
- Fixed module initialization bug in `discover_apps` where plugin modules were never registered in `sys.modules`
- This caused the Slack simulator's `send` endpoint to get an uninitialized module copy, returning `{"error": "Bridge not initialized"}` on every request

## Bug Details
`discover_apps` used `importlib.util.spec_from_file_location` + `exec_module` to load app plugin modules but never registered them in `sys.modules`. This created two separate module instances — one file-loaded (with initialized `_state`), one in `sys.modules` (empty). When the Slack simulator's `send` endpoint did `from . import _state`, it got the uninitialized `sys.modules` copy.

## The Fix
Register the module in `sys.modules` before executing it — the standard Python pattern for `importlib`-based module loading. One line: `sys.modules[module_name] = module`.

## Verification
✅ Full WebSocket trace confirms the pipeline works end-to-end after the fix

## Changes
Only `src/amplifier_distro/server/app.py`:
- Added `import sys` to imports
- Added `sys.modules[module_name] = module` before `spec.loader.exec_module(module)`